### PR TITLE
Default Salt Length & Extra 'Token' value inside KB-Jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ as well as retrieving all disclosed claims in line with the specification.
 
 For more information on SD-JWTs, see the [Selective Disclosure JWTs RFC](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-05.html)
 
+Also see: [sdjwt.org](https://sdjwt.org/) for a playground powered by this module
+
 ## Requirements
 - Go 1.21 or higher
 

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ This object represents a single disclosure in a SD-JWT. The EncodedValue propert
 ```go
 func NewFromObject(key string, value any, salt *string) (*Disclosure, error)
 ```
-NewFromObject creates a Disclosure object for the provided key/value pair and optional salt. If no salt provided, a new salt value of 128 bytes is generated
+NewFromObject creates a Disclosure object for the provided key/value pair and optional salt. If no salt provided, a new salt value of 128 bits is generated
 
 ```go
 func NewFromArrayElement(element any, salt *string) (*Disclosure, error)
 ```
-NewFromArrayElement creates a Disclosure object for the provided array element and optional salt. If no salt provided, a new salt value of 128 bytes is generated
+NewFromArrayElement creates a Disclosure object for the provided array element and optional salt. If no salt provided, a new salt value of 128 bits is generated
 
 ```go
 func NewFromDisclosure(disclosure string) (*Disclosure, error)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Package go_sd_jwt provides a library for creating and validating SD-JWTs. The
 resulting SdJwt object exposes methods for retrieving the claims and disclosures
 as well as retrieving all disclosed claims in line with the specification.
 
-For more information on SD-JWTs, see the [Selective Disclosure JWTs RFC](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-05.html)
+For more information on SD-JWTs, see the [Selective Disclosure JWTs Specification](https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/)
 
 Also see: [sdjwt.org](https://sdjwt.org/) for a playground powered by this module
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -418,7 +418,7 @@ func TestE2E(t *testing.T) {
 			t.Fatalf("error generating nonce value: %s", err.Error())
 		}
 
-		err = providedSdJwt.AddKeyBindingJwt(holderSigner, crypto.SHA256, holderSigner.Alg().String(), "https://audience.com", string(nonce))
+		err = providedSdJwt.AddKeyBindingJwt(holderSigner, crypto.SHA256, holderSigner.Alg().String(), "https://audience.com", base64.RawURLEncoding.EncodeToString(nonce))
 		if err != nil {
 			t.Fatalf("error adding kb jwt: %s", err.Error())
 		}

--- a/internal/salt/salt.go
+++ b/internal/salt/salt.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewSalt() (*string, error) {
-	randomBytes := make([]byte, 128)
+	randomBytes := make([]byte, 16)
 	_, err := rand.Read(randomBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error generating salt value: %w", err)

--- a/kbjwt/kbjwt.go
+++ b/kbjwt/kbjwt.go
@@ -13,7 +13,7 @@ type KbJwt struct {
 	Aud    *string `json:"aud"`
 	Nonce  *string `json:"nonce"`
 	SdHash *string `json:"sd_hash"`
-	Token  string
+	Token  string  `json:"-"`
 }
 
 func NewFromToken(token string) (*KbJwt, error) {


### PR DESCRIPTION
- adjusted default length of disclosure salt value to align with that recommended by the spec
- fixed issue where an empty value of 'Token' would appear inside the key binding jwt
- updated README to point at updated specification link
- added link to sdjwt.org on README