### PR TITLE
Fix robustness issues: safe type assertions, nil guards, error messages, case sensitivity

### DIFF
--- a/disclosure/disclosure.go
+++ b/disclosure/disclosure.go
@@ -32,7 +32,7 @@ func (d *Disclosure) Hash(hash hash.Hash) []byte {
 
 func NewFromObject(key string, value any, salt *string) (*Disclosure, error) {
 	if key == "" || key == "_sd" || key == "..." {
-		return nil, fmt.Errorf("%winvalid key value provided, must not be empty, '_sd', or '...'", e.ErrInvalidDisclosure)
+		return nil, fmt.Errorf("%wkey must not be empty, '_sd', or '...'", e.ErrInvalidDisclosure)
 	}
 
 	var saltValue string
@@ -102,24 +102,36 @@ func NewFromDisclosure(disclosure string) (*Disclosure, error) {
 
 	decoded, err := base64.RawURLEncoding.DecodeString(disclosure)
 	if err != nil {
-		return nil, fmt.Errorf("%werror base64url decoding provided disclosure: %s", e.ErrInvalidDisclosure, err.Error())
+		return nil, fmt.Errorf("%wfailed to base64url decode: %s", e.ErrInvalidDisclosure, err.Error())
 	}
 
 	var dArray []any
 	err = json.Unmarshal(decoded, &dArray)
 	if err != nil {
-		return nil, fmt.Errorf("%werror parsing decoded disclosure as array: %s", e.ErrInvalidDisclosure, err.Error())
+		return nil, fmt.Errorf("%wfailed to parse as array: %s", e.ErrInvalidDisclosure, err.Error())
 	}
 
 	if len(dArray) == 2 {
-		d.Salt = dArray[0].(string)
+		salt, ok := dArray[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("%wsalt value is not a string", e.ErrInvalidDisclosure)
+		}
+		d.Salt = salt
 		d.Value = dArray[1]
 	} else if len(dArray) == 3 {
-		d.Salt = dArray[0].(string)
-		d.Key = String(dArray[1].(string))
+		salt, ok := dArray[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("%wsalt value is not a string", e.ErrInvalidDisclosure)
+		}
+		key, ok := dArray[1].(string)
+		if !ok {
+			return nil, fmt.Errorf("%wkey value is not a string", e.ErrInvalidDisclosure)
+		}
+		d.Salt = salt
+		d.Key = String(key)
 		d.Value = dArray[2]
 	} else {
-		return nil, fmt.Errorf("%winvalid disclosure contents: %s", e.ErrInvalidDisclosure, string(decoded))
+		return nil, fmt.Errorf("%wunexpected contents: %s", e.ErrInvalidDisclosure, string(decoded))
 	}
 
 	return d, nil

--- a/disclosure/disclosure_test.go
+++ b/disclosure/disclosure_test.go
@@ -138,3 +138,35 @@ func TestDisclosure_Hash(t *testing.T) {
 		t.Errorf("unexpected hash result: %s", string(arrayHash))
 	}
 }
+
+func TestNewFromDisclosure_NonStringSalt(t *testing.T) {
+	t.Run("non-string salt in object disclosure", func(t *testing.T) {
+		_, err := NewFromDisclosure("WzEyMywia2V5IiwidmFsdWUiXQ")
+		if err == nil {
+			t.Fatal("expected error for non-string salt")
+		}
+		if err.Error() != "invalid disclosure: salt value is not a string" {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+	})
+
+	t.Run("non-string key in object disclosure", func(t *testing.T) {
+		_, err := NewFromDisclosure("WyJzYWx0Iiw0NTYsInZhbHVlIl0")
+		if err == nil {
+			t.Fatal("expected error for non-string key")
+		}
+		if err.Error() != "invalid disclosure: key value is not a string" {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+	})
+
+	t.Run("non-string salt in array disclosure", func(t *testing.T) {
+		_, err := NewFromDisclosure("WzEyMywidmFsdWUiXQ")
+		if err == nil {
+			t.Fatal("expected error for non-string salt")
+		}
+		if err.Error() != "invalid disclosure: salt value is not a string" {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+	})
+}

--- a/internal/error/error.go
+++ b/internal/error/error.go
@@ -2,5 +2,5 @@ package error
 
 import "errors"
 
-var ErrInvalidToken = errors.New("")
-var ErrInvalidDisclosure = errors.New("")
+var ErrInvalidToken = errors.New("invalid token: ")
+var ErrInvalidDisclosure = errors.New("invalid disclosure: ")

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -11,6 +11,9 @@ import (
 
 func ValidateArrayClaims(s *[]any, currentDisclosure *disclosure.Disclosure, base64HashedDisclosure string) (found bool, err error) {
 	for i, v := range *s {
+		if v == nil {
+			continue
+		}
 
 		switch reflect.TypeOf(v).Kind() {
 
@@ -68,7 +71,7 @@ func ValidateSDClaims(values *map[string]any, currentDisclosure *disclosure.Disc
 	}
 
 	for k, v := range *values {
-		if k != "_sd" && k != "_sd_alg" {
+		if k != "_sd" && k != "_sd_alg" && v != nil {
 			if reflect.TypeOf(v).Kind() == reflect.Slice {
 				found, err = ValidateArrayClaims(PointerSlice(v.([]any)), currentDisclosure, base64HashedDisclosure)
 				if err != nil {
@@ -91,6 +94,9 @@ func ValidateSDClaims(values *map[string]any, currentDisclosure *disclosure.Disc
 func GetDigests(m map[string]any) []any {
 	var digests []any
 	for k, v := range m {
+		if v == nil {
+			continue
+		}
 		if reflect.TypeOf(v).Kind() == reflect.Map {
 			digests = append(digests, GetDigests(v.(map[string]any))...)
 		} else if k == "_sd" {
@@ -114,6 +120,10 @@ func GetDigests(m map[string]any) []any {
 func StripSDClaimsFromSlice(input []any) []any {
 	var output []any
 	for _, v := range input {
+		if v == nil {
+			output = append(output, v)
+			continue
+		}
 		switch reflect.TypeOf(v).Kind() {
 		case reflect.Map:
 			strippedValue := StripSDClaims(v.(map[string]any))
@@ -140,6 +150,10 @@ func StripSDClaims(body map[string]any) map[string]any {
 	omit := true
 	bodyMap := make(map[string]any)
 	for k, v := range body {
+		if v == nil {
+			bodyMap[k] = v
+			continue
+		}
 		switch reflect.TypeOf(v).Kind() {
 		case reflect.Map:
 			strippedValue := StripSDClaims(v.(map[string]any))

--- a/kbjwt/kbjwt.go
+++ b/kbjwt/kbjwt.go
@@ -20,7 +20,7 @@ func NewFromToken(token string) (*KbJwt, error) {
 	kbjc := strings.Split(token, ".")
 
 	if len(kbjc) != 3 {
-		return nil, fmt.Errorf("%wkb jwt is in an invalid format", e.ErrInvalidToken)
+		return nil, fmt.Errorf("%wkb-jwt is in an invalid format", e.ErrInvalidToken)
 	}
 
 	//head
@@ -35,7 +35,7 @@ func NewFromToken(token string) (*KbJwt, error) {
 	}
 
 	if kbh["typ"] != "kb+jwt" {
-		return nil, fmt.Errorf("%wkb jwt is not of type kb+jwt", e.ErrInvalidToken)
+		return nil, fmt.Errorf("%wkb-jwt is not of type kb+jwt", e.ErrInvalidToken)
 	}
 
 	//body

--- a/sd-jwt.go
+++ b/sd-jwt.go
@@ -96,7 +96,7 @@ func (s *SdJwt) AddKeyBindingJwt(signer crypto.Signer, h crypto.Hash, alg, aud, 
 	}
 
 	sdAlg, ok := s.Body["_sd_alg"].(string)
-	if (ok && !strings.EqualFold(sdAlg, h.String())) || (!ok && strings.ToLower(h.String()) != "sha-256") {
+	if (ok && sdAlg != strings.ToLower(h.String())) || (!ok && strings.ToLower(h.String()) != "sha-256") {
 		return errors.New("key binding jwt hashing algorithm does not match the hashing algorithm specified in the sd-jwt - if sd-jwt does not specify a hashing algorithm, sha-256 is selected by default")
 	}
 
@@ -174,7 +174,7 @@ func (s *SdJwt) AddKeyBindingJwt(signer crypto.Signer, h crypto.Hash, alg, aud, 
 
 func GetHash(hashString string) (hash.Hash, error) {
 	var h hash.Hash
-	switch strings.ToLower(hashString) {
+	switch hashString {
 	case "sha-256", "":
 		// default to sha-256
 		h = sha256.New()
@@ -272,13 +272,13 @@ func validateJwt(token string) (*SdJwt, error) {
 
 	sections := strings.Split(token, "~")
 	if len(sections) < 2 {
-		return nil, fmt.Errorf("%wtoken has no specified disclosures", e.ErrInvalidToken)
+		return nil, fmt.Errorf("%wno specified disclosures", e.ErrInvalidToken)
 	}
 
 	tokenSections := strings.Split(sections[0], ".")
 
 	if len(tokenSections) != 3 {
-		return nil, fmt.Errorf("%wtoken is not a valid JWT", e.ErrInvalidToken)
+		return nil, fmt.Errorf("%wnot a valid JWT", e.ErrInvalidToken)
 	}
 
 	jwtHead := map[string]any{}
@@ -300,7 +300,7 @@ func validateJwt(token string) (*SdJwt, error) {
 		kbJwt := utils.CheckForKbJwt(sections[len(sections)-1])
 
 		if kbJwt == nil {
-			return nil, fmt.Errorf("%wif no kb-jwt is provided, the last disclosure must be followed by a ~", e.ErrInvalidToken)
+			return nil, fmt.Errorf("%wlast disclosure must be followed by a ~ when no kb-jwt is provided", e.ErrInvalidToken)
 		}
 
 		sections = sections[:len(sections)-1]

--- a/sd-jwt.go
+++ b/sd-jwt.go
@@ -96,7 +96,11 @@ func (s *SdJwt) AddKeyBindingJwt(signer crypto.Signer, h crypto.Hash, alg, aud, 
 	}
 
 	sdAlg, ok := s.Body["_sd_alg"].(string)
-	if (ok && sdAlg != strings.ToLower(h.String())) || (!ok && strings.ToLower(h.String()) != "sha-256") {
+	ianaName, err := hashToIANAName(h)
+	if err != nil {
+		return err
+	}
+	if (ok && sdAlg != ianaName) || (!ok && ianaName != "sha-256") {
 		return errors.New("key binding jwt hashing algorithm does not match the hashing algorithm specified in the sd-jwt - if sd-jwt does not specify a hashing algorithm, sha-256 is selected by default")
 	}
 
@@ -200,6 +204,33 @@ func GetHash(hashString string) (hash.Hash, error) {
 		return nil, errors.New("unsupported _sd_alg: " + hashString)
 	}
 	return h, nil
+}
+
+func hashToIANAName(h crypto.Hash) (string, error) {
+	switch h {
+	case crypto.SHA256:
+		return "sha-256", nil
+	case crypto.SHA224:
+		return "sha-224", nil
+	case crypto.SHA512:
+		return "sha-512", nil
+	case crypto.SHA384:
+		return "sha-384", nil
+	case crypto.SHA512_224:
+		return "sha-512/224", nil
+	case crypto.SHA512_256:
+		return "sha-512/256", nil
+	case crypto.SHA3_224:
+		return "sha3-224", nil
+	case crypto.SHA3_256:
+		return "sha3-256", nil
+	case crypto.SHA3_384:
+		return "sha3-384", nil
+	case crypto.SHA3_512:
+		return "sha3-512", nil
+	default:
+		return "", fmt.Errorf("unsupported hash algorithm: %s", h.String())
+	}
 }
 
 // GetDisclosedClaims returns the claims that were disclosed in the token or included as plaintext values.

--- a/sd-jwt_test.go
+++ b/sd-jwt_test.go
@@ -487,7 +487,7 @@ func TestNew(t *testing.T) {
 				if sdJwt != nil {
 					t.Error("sdJwt should be nil")
 				}
-				assert.Equal(t, "sd hash validation failed: calculated hash imDBfEoPQdkucAP7SGAGAbZCYsb5U3l9VFDETTJ9eQQ does not equal provided hash nYcOXyP43v9szKryn_k_4GkRr_j3STHhNSS-i1Duauo", err.Error())
+				assert.Equal(t, "invalid token: sd hash validation failed: calculated hash imDBfEoPQdkucAP7SGAGAbZCYsb5U3l9VFDETTJ9eQQ does not equal provided hash nYcOXyP43v9szKryn_k_4GkRr_j3STHhNSS-i1Duauo", err.Error())
 			},
 		},
 		"valid token but duplicate disclosure": {
@@ -500,7 +500,7 @@ func TestNew(t *testing.T) {
 				if sdJwt != nil {
 					t.Error("sdJwt should be nil: ", sdJwt)
 				}
-				if err.Error() != "failed to validate disclosures: duplicate disclosure found" {
+				if err.Error() != "invalid token: failed to validate disclosures: duplicate disclosure found" {
 					t.Error("error message is not correct: ", err.Error())
 				}
 			},
@@ -729,7 +729,7 @@ func TestNewFromComponentsWrongKbJwt(t *testing.T) {
 	if sdJwt != nil {
 		t.Error("sdJwt should be nil")
 	}
-	assert.Equal(t, "sd hash validation failed: calculated hash nYcOXyP43v9szKryn_k_4GkRr_j3STHhNSS-i1Duauo does not equal provided hash imDBfEoPQdkucAP7SGAGAbZCYsb5U3l9VFDETTJ9eQQ", err.Error())
+	assert.Equal(t, "invalid token: sd hash validation failed: calculated hash nYcOXyP43v9szKryn_k_4GkRr_j3STHhNSS-i1Duauo does not equal provided hash imDBfEoPQdkucAP7SGAGAbZCYsb5U3l9VFDETTJ9eQQ", err.Error())
 }
 
 func TestSdJwt_AddKeyBindingJwt(t *testing.T) {
@@ -805,7 +805,7 @@ func TestNew_AllDuplicateDigestScenarios(t *testing.T) {
 			t.Log("iteration: ", i)
 			t.Error("sdJwt should be nil: ", sdJwt)
 		}
-		if err.Error() != "failed to validate digests: duplicate digest found" {
+		if err.Error() != "invalid token: failed to validate digests: duplicate digest found" {
 			t.Log("iteration: ", i)
 			t.Error("error message is not correct: ", err.Error())
 		}
@@ -813,7 +813,7 @@ func TestNew_AllDuplicateDigestScenarios(t *testing.T) {
 }
 
 func TestSDJwtWithoutSD(t *testing.T) {
-	testJwt := "eyJ0eXAiOiJzZCtqd3QiLCJhbGciOiJFUzI1NiJ9.eyJmaXJzdG5hbWUiOiJKb2huIiwibGFzdG5hbWUiOiJEb2UiLCJzc24iOiIxMjMtNDUtNjc4OSIsImlkIjoiMTIzNCIsIl9zZF9hbGciOiJTSEEtMjU2In0.sUA_aYeA4YNQ1Paxna30VLAce1KdxvYMPEIduCwSD6X_Z56ZrBY5fbUBM5JVQ3vceS86CCghr8wkemdhQYRdfA~"
+	testJwt := "eyJ0eXAiOiJzZCtqd3QiLCJhbGciOiJFUzI1NiJ9.eyJmaXJzdG5hbWUiOiJKb2huIiwibGFzdG5hbWUiOiJEb2UiLCJzc24iOiIxMjMtNDUtNjc4OSIsImlkIjoiMTIzNCIsIl9zZF9hbGciOiJzaGEtMjU2In0.sUA_aYeA4YNQ1Paxna30VLAce1KdxvYMPEIduCwSD6X_Z56ZrBY5fbUBM5JVQ3vceS86CCghr8wkemdhQYRdfA~"
 	sdJwt, err := go_sd_jwt.New(testJwt)
 
 	if err != nil {

--- a/sd-jwt_test.go
+++ b/sd-jwt_test.go
@@ -827,3 +827,43 @@ func TestSDJwtWithoutSD(t *testing.T) {
 		t.Fatalf("The token has empty selective disclosure but fails in parsing: %s", err.Error())
 	}
 }
+
+func TestGetHash_CaseSensitive(t *testing.T) {
+	t.Run("lowercase sha-256 accepted", func(t *testing.T) {
+		_, err := go_sd_jwt.GetHash("sha-256")
+		if err != nil {
+			t.Fatalf("should accept lowercase sha-256: %s", err.Error())
+		}
+	})
+
+	t.Run("uppercase SHA-256 rejected", func(t *testing.T) {
+		_, err := go_sd_jwt.GetHash("SHA-256")
+		if err == nil {
+			t.Fatal("should reject uppercase SHA-256")
+		}
+	})
+
+	t.Run("mixed case Sha-256 rejected", func(t *testing.T) {
+		_, err := go_sd_jwt.GetHash("Sha-256")
+		if err == nil {
+			t.Fatal("should reject mixed case Sha-256")
+		}
+	})
+}
+
+func TestSDJwtWithNullValues(t *testing.T) {
+	token := "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ0ZXN0IiwibnVsbGZpZWxkIjpudWxsLCJfc2RfYWxnIjoic2hhLTI1NiJ9.fakesig~"
+	sdJwt, err := go_sd_jwt.New(token)
+	if err != nil {
+		t.Fatalf("should parse token with null values: %s", err.Error())
+	}
+
+	claims, err := sdJwt.GetDisclosedClaims()
+	if err != nil {
+		t.Fatalf("should handle null values in GetDisclosedClaims: %s", err.Error())
+	}
+
+	if claims["nullfield"] != nil {
+		t.Error("null field should remain nil")
+	}
+}

--- a/sd-jwt_test.go
+++ b/sd-jwt_test.go
@@ -841,6 +841,7 @@ func TestGetHash_CaseSensitive(t *testing.T) {
 		if err == nil {
 			t.Fatal("should reject uppercase SHA-256")
 		}
+		assert.Equal(t, "unsupported _sd_alg: SHA-256", err.Error())
 	})
 
 	t.Run("mixed case Sha-256 rejected", func(t *testing.T) {
@@ -848,6 +849,7 @@ func TestGetHash_CaseSensitive(t *testing.T) {
 		if err == nil {
 			t.Fatal("should reject mixed case Sha-256")
 		}
+		assert.Equal(t, "unsupported _sd_alg: Sha-256", err.Error())
 	})
 }
 


### PR DESCRIPTION
## Summary
- **Safe type assertions** in `disclosure.NewFromDisclosure()` — prevents panics on malformed disclosure input (DoS vector)
- **Nil guards** in `internal/utils` — prevents nil pointer dereference on null JSON values in `ValidateSDClaims`, `ValidateArrayClaims`, `GetDigests`, `StripSDClaims`, and `StripSDClaimsFromSlice`
- **Meaningful sentinel errors** — `ErrInvalidToken` and `ErrInvalidDisclosure` now carry descriptive prefixes; all call sites updated for grammatical consistency
- **Case-sensitive `_sd_alg`** — `GetHash` and `AddKeyBindingJwt` now match exact IANA registry values (lowercase) instead of case-insensitive comparison

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Updated test assertions for new error message format
- [x] Updated test token in `TestSDJwtWithoutSD` to use spec-compliant lowercase `sha-256`
- [ ] Verify `errors.Is(err, ErrInvalidToken)` still works as expected
- [ ] Test with malformed disclosures containing non-string salt/key values