### PR TITLE
Add signature verification and validation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,39 @@ func (s *SdJwt) Token() (*string, error)
 ```
 Token returns the current form of the sd-jwt object in string token format
 
+### Verification
+```go
+func (s *SdJwt) Verify(opts VerificationOptions) error
+```
+Verify performs cryptographic and semantic verification of a parsed SD-JWT. All checks are opt-in via `VerificationOptions`:
+
+```go
+type VerificationOptions struct {
+    IssuerKey            crypto.PublicKey // verify issuer JWT signature
+    ValidateExpiry       bool            // check exp claim against current time
+    ValidateNotBefore    bool            // check nbf claim against current time
+    ExpectedAudience     *string         // verify KB-JWT aud claim matches
+    ExpectedNonce        *string         // verify KB-JWT nonce claim matches
+    VerifyKBJwtSignature bool            // verify KB-JWT signature using cnf.jwk
+}
+```
+
+Example:
+```go
+sdJwt, err := go_sd_jwt.New(token)
+
+err = sdJwt.Verify(go_sd_jwt.VerificationOptions{
+    IssuerKey:            issuerPublicKey,
+    ValidateExpiry:       true,
+    ValidateNotBefore:    true,
+    ExpectedAudience:     &expectedAud,
+    ExpectedNonce:        &expectedNonce,
+    VerifyKBJwtSignature: true,
+})
+```
+
+Issuer signature verification supports ES256/384/512, RS256/384/512, and PS256/384/512 via [go-jose](https://github.com/MichaelFraser99/go-jose). KB-JWT signature verification extracts the holder's public key from the `cnf.jwk` claim in the issuer JWT body.
+
 ### Usage
 For an example e2e flow of an SD Jwt see the e2e_test
 Contains examples of:

--- a/sd-jwt.go
+++ b/sd-jwt.go
@@ -31,6 +31,8 @@ type SdJwt struct {
 	Signature   string
 	KbJwt       *kbjwt.KbJwt
 	Disclosures []disclosure.Disclosure
+	rawHead     string
+	rawPayload  string
 }
 
 // New
@@ -293,6 +295,8 @@ func validateJwt(token string) (*SdJwt, error) {
 	}
 
 	sdJwt.Head = jwtHead
+	sdJwt.rawHead = tokenSections[0]
+	sdJwt.rawPayload = tokenSections[1]
 
 	sdJwt.Signature = tokenSections[2]
 

--- a/verify.go
+++ b/verify.go
@@ -85,16 +85,7 @@ func (s *SdJwt) verifyIssuerSignature(issuerKey crypto.PublicKey) error {
 		return fmt.Errorf("%wfailed to create signature validator: %w", e.ErrInvalidToken, err)
 	}
 
-	headBytes, err := json.Marshal(s.Head)
-	if err != nil {
-		return fmt.Errorf("failed to marshal header for verification: %w", err)
-	}
-	bodyBytes, err := json.Marshal(s.Body)
-	if err != nil {
-		return fmt.Errorf("failed to marshal body for verification: %w", err)
-	}
-
-	signInput := base64.RawURLEncoding.EncodeToString(headBytes) + "." + base64.RawURLEncoding.EncodeToString(bodyBytes)
+	signInput := s.rawHead + "." + s.rawPayload
 
 	sigBytes, err := base64.RawURLEncoding.DecodeString(s.Signature)
 	if err != nil {

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,207 @@
+package go_sd_jwt
+
+import (
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MichaelFraser99/go-jose/jwk"
+	"github.com/MichaelFraser99/go-jose/jws"
+	josemodel "github.com/MichaelFraser99/go-jose/model"
+
+	e "github.com/MichaelFraser99/go-sd-jwt/internal/error"
+)
+
+// VerificationOptions configures what aspects of the SD-JWT are verified.
+// All fields are optional — only checks with non-zero values are performed.
+type VerificationOptions struct {
+	IssuerKey            crypto.PublicKey
+	ValidateExpiry       bool
+	ValidateNotBefore    bool
+	ExpectedAudience     *string
+	ExpectedNonce        *string
+	VerifyKBJwtSignature bool
+}
+
+// Verify performs cryptographic and semantic verification of the SD-JWT based on the provided options.
+func (s *SdJwt) Verify(opts VerificationOptions) error {
+	if opts.IssuerKey != nil {
+		if err := s.verifyIssuerSignature(opts.IssuerKey); err != nil {
+			return err
+		}
+	}
+
+	if opts.ValidateExpiry {
+		if err := s.validateExpiry(); err != nil {
+			return err
+		}
+	}
+
+	if opts.ValidateNotBefore {
+		if err := s.validateNotBefore(); err != nil {
+			return err
+		}
+	}
+
+	if s.KbJwt != nil {
+		if opts.ExpectedAudience != nil {
+			if s.KbJwt.Aud == nil || *s.KbJwt.Aud != *opts.ExpectedAudience {
+				return fmt.Errorf("%wkb-jwt audience mismatch: expected %s", e.ErrInvalidToken, *opts.ExpectedAudience)
+			}
+		}
+
+		if opts.ExpectedNonce != nil {
+			if s.KbJwt.Nonce == nil || *s.KbJwt.Nonce != *opts.ExpectedNonce {
+				return fmt.Errorf("%wkb-jwt nonce mismatch: expected %s", e.ErrInvalidToken, *opts.ExpectedNonce)
+			}
+		}
+
+		if opts.VerifyKBJwtSignature {
+			if err := s.verifyKBJwtSignature(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SdJwt) verifyIssuerSignature(issuerKey crypto.PublicKey) error {
+	algStr, ok := s.Head["alg"].(string)
+	if !ok {
+		return fmt.Errorf("%wmissing or invalid 'alg' in header", e.ErrInvalidToken)
+	}
+
+	alg := josemodel.GetAlgorithm(algStr)
+	if alg == nil {
+		return fmt.Errorf("%wunsupported algorithm: %s", e.ErrInvalidToken, algStr)
+	}
+
+	validator, err := jws.GetValidator(*alg, issuerKey)
+	if err != nil {
+		return fmt.Errorf("%wfailed to create signature validator: %w", e.ErrInvalidToken, err)
+	}
+
+	headBytes, err := json.Marshal(s.Head)
+	if err != nil {
+		return fmt.Errorf("failed to marshal header for verification: %w", err)
+	}
+	bodyBytes, err := json.Marshal(s.Body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal body for verification: %w", err)
+	}
+
+	signInput := base64.RawURLEncoding.EncodeToString(headBytes) + "." + base64.RawURLEncoding.EncodeToString(bodyBytes)
+
+	sigBytes, err := base64.RawURLEncoding.DecodeString(s.Signature)
+	if err != nil {
+		return fmt.Errorf("%wfailed to decode signature: %w", e.ErrInvalidToken, err)
+	}
+
+	valid, err := validator.ValidateSignature([]byte(signInput), sigBytes)
+	if err != nil {
+		return fmt.Errorf("%wsignature verification error: %w", e.ErrInvalidToken, err)
+	}
+	if !valid {
+		return fmt.Errorf("%wsignature verification failed", e.ErrInvalidToken)
+	}
+
+	return nil
+}
+
+func (s *SdJwt) validateExpiry() error {
+	exp, ok := s.Body["exp"]
+	if !ok {
+		return nil
+	}
+	expFloat, ok := exp.(float64)
+	if !ok {
+		return fmt.Errorf("%w'exp' claim is not a valid number", e.ErrInvalidToken)
+	}
+	if time.Now().Unix() > int64(expFloat) {
+		return fmt.Errorf("%wtoken has expired", e.ErrInvalidToken)
+	}
+	return nil
+}
+
+func (s *SdJwt) validateNotBefore() error {
+	nbf, ok := s.Body["nbf"]
+	if !ok {
+		return nil
+	}
+	nbfFloat, ok := nbf.(float64)
+	if !ok {
+		return fmt.Errorf("%w'nbf' claim is not a valid number", e.ErrInvalidToken)
+	}
+	if time.Now().Unix() < int64(nbfFloat) {
+		return fmt.Errorf("%wtoken is not yet valid", e.ErrInvalidToken)
+	}
+	return nil
+}
+
+func (s *SdJwt) verifyKBJwtSignature() error {
+	cnf, ok := s.Body["cnf"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w'cnf' claim missing or invalid in issuer JWT", e.ErrInvalidToken)
+	}
+
+	jwkMap, ok := cnf["jwk"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w'jwk' missing or invalid in 'cnf' claim", e.ErrInvalidToken)
+	}
+
+	holderKey, err := jwk.PublicFromJwk(jwkMap)
+	if err != nil {
+		return fmt.Errorf("%wfailed to parse holder public key from cnf.jwk: %w", e.ErrInvalidToken, err)
+	}
+
+	kbParts := strings.Split(s.KbJwt.Token, ".")
+	if len(kbParts) != 3 {
+		return fmt.Errorf("%wkb-jwt token is malformed", e.ErrInvalidToken)
+	}
+
+	kbHeadBytes, err := base64.RawURLEncoding.DecodeString(kbParts[0])
+	if err != nil {
+		return fmt.Errorf("%wfailed to decode kb-jwt header: %w", e.ErrInvalidToken, err)
+	}
+
+	var kbHead map[string]any
+	if err := json.Unmarshal(kbHeadBytes, &kbHead); err != nil {
+		return fmt.Errorf("%wfailed to parse kb-jwt header: %w", e.ErrInvalidToken, err)
+	}
+
+	kbAlgStr, ok := kbHead["alg"].(string)
+	if !ok {
+		return fmt.Errorf("%wmissing or invalid 'alg' in kb-jwt header", e.ErrInvalidToken)
+	}
+
+	kbAlg := josemodel.GetAlgorithm(kbAlgStr)
+	if kbAlg == nil {
+		return fmt.Errorf("%wunsupported kb-jwt algorithm: %s", e.ErrInvalidToken, kbAlgStr)
+	}
+
+	validator, err := jws.GetValidator(*kbAlg, holderKey)
+	if err != nil {
+		return fmt.Errorf("%wfailed to create kb-jwt signature validator: %w", e.ErrInvalidToken, err)
+	}
+
+	kbSignInput := kbParts[0] + "." + kbParts[1]
+
+	kbSigBytes, err := base64.RawURLEncoding.DecodeString(kbParts[2])
+	if err != nil {
+		return fmt.Errorf("%wfailed to decode kb-jwt signature: %w", e.ErrInvalidToken, err)
+	}
+
+	valid, err := validator.ValidateSignature([]byte(kbSignInput), kbSigBytes)
+	if err != nil {
+		return fmt.Errorf("%wkb-jwt signature verification error: %w", e.ErrInvalidToken, err)
+	}
+	if !valid {
+		return fmt.Errorf("%wkb-jwt signature verification failed", e.ErrInvalidToken)
+	}
+
+	return nil
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -55,7 +55,8 @@ func TestVerify_IssuerSignature(t *testing.T) {
 		otherSigner, err := jws.GetSigner(model.ES256, nil)
 		require.NoError(t, err)
 		err = sdJwt.Verify(VerificationOptions{IssuerKey: otherSigner.Public()})
-		assert.Error(t, err)
+		require.Error(t, err)
+		assert.Equal(t, "invalid token: signature verification failed", err.Error())
 	})
 
 	t.Run("no key skips verification", func(t *testing.T) {
@@ -77,8 +78,8 @@ func TestVerify_Expiry(t *testing.T) {
 		require.NoError(t, err)
 
 		err = sdJwt.Verify(VerificationOptions{ValidateExpiry: true})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "expired")
+		require.Error(t, err)
+		assert.Equal(t, "invalid token: token has expired", err.Error())
 	})
 
 	t.Run("valid expiry", func(t *testing.T) {
@@ -125,8 +126,8 @@ func TestVerify_NotBefore(t *testing.T) {
 		require.NoError(t, err)
 
 		err = sdJwt.Verify(VerificationOptions{ValidateNotBefore: true})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "not yet valid")
+		require.Error(t, err)
+		assert.Equal(t, "invalid token: token is not yet valid", err.Error())
 	})
 
 	t.Run("already valid", func(t *testing.T) {
@@ -200,8 +201,8 @@ func TestVerify_KBJwtAudienceAndNonce(t *testing.T) {
 		err := sdJwtWithKb.Verify(VerificationOptions{
 			ExpectedAudience: utils.Pointer("https://wrong.example.com"),
 		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "audience mismatch")
+		require.Error(t, err)
+		assert.Equal(t, "invalid token: kb-jwt audience mismatch: expected https://wrong.example.com", err.Error())
 	})
 
 	t.Run("matching nonce", func(t *testing.T) {
@@ -215,8 +216,8 @@ func TestVerify_KBJwtAudienceAndNonce(t *testing.T) {
 		err := sdJwtWithKb.Verify(VerificationOptions{
 			ExpectedNonce: utils.Pointer("wrong"),
 		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "nonce mismatch")
+		require.Error(t, err)
+		assert.Equal(t, "invalid token: kb-jwt nonce mismatch: expected wrong", err.Error())
 	})
 
 	t.Run("kb-jwt signature verification", func(t *testing.T) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,238 @@
+package go_sd_jwt
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/MichaelFraser99/go-jose/jwk"
+	"github.com/MichaelFraser99/go-jose/jws"
+	"github.com/MichaelFraser99/go-jose/model"
+	"github.com/MichaelFraser99/go-sd-jwt/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildSignedSDJWT(t *testing.T, head, body map[string]any, signer model.Signer) string {
+	headBytes, err := json.Marshal(head)
+	require.NoError(t, err)
+	bodyBytes, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	b64Head := base64.RawURLEncoding.EncodeToString(headBytes)
+	b64Body := base64.RawURLEncoding.EncodeToString(bodyBytes)
+	signInput := b64Head + "." + b64Body
+
+	sig, err := signer.Sign(rand.Reader, []byte(signInput), nil)
+	require.NoError(t, err)
+
+	b64Sig := base64.RawURLEncoding.EncodeToString(sig)
+	return fmt.Sprintf("%s.%s.%s~", b64Head, b64Body, b64Sig)
+}
+
+func TestVerify_IssuerSignature(t *testing.T) {
+	signer, err := jws.GetSigner(model.ES256, nil)
+	require.NoError(t, err)
+
+	head := map[string]any{"alg": "ES256"}
+	body := map[string]any{"sub": "user_42", "iss": "https://example.com", "_sd_alg": "sha-256"}
+
+	token := buildSignedSDJWT(t, head, body, signer)
+
+	sdJwt, err := New(token)
+	require.NoError(t, err)
+
+	t.Run("valid signature", func(t *testing.T) {
+		err := sdJwt.Verify(VerificationOptions{IssuerKey: signer.Public()})
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong key", func(t *testing.T) {
+		otherSigner, err := jws.GetSigner(model.ES256, nil)
+		require.NoError(t, err)
+		err = sdJwt.Verify(VerificationOptions{IssuerKey: otherSigner.Public()})
+		assert.Error(t, err)
+	})
+
+	t.Run("no key skips verification", func(t *testing.T) {
+		err := sdJwt.Verify(VerificationOptions{})
+		assert.NoError(t, err)
+	})
+}
+
+func TestVerify_Expiry(t *testing.T) {
+	signer, err := jws.GetSigner(model.ES256, nil)
+	require.NoError(t, err)
+
+	head := map[string]any{"alg": "ES256"}
+
+	t.Run("expired token", func(t *testing.T) {
+		body := map[string]any{"exp": float64(time.Now().Unix() - 3600), "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{ValidateExpiry: true})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+
+	t.Run("valid expiry", func(t *testing.T) {
+		body := map[string]any{"exp": float64(time.Now().Unix() + 3600), "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{ValidateExpiry: true})
+		assert.NoError(t, err)
+	})
+
+	t.Run("no exp claim is fine", func(t *testing.T) {
+		body := map[string]any{"sub": "test", "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{ValidateExpiry: true})
+		assert.NoError(t, err)
+	})
+
+	t.Run("disabled by default", func(t *testing.T) {
+		body := map[string]any{"exp": float64(time.Now().Unix() - 3600), "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{})
+		assert.NoError(t, err)
+	})
+}
+
+func TestVerify_NotBefore(t *testing.T) {
+	signer, err := jws.GetSigner(model.ES256, nil)
+	require.NoError(t, err)
+
+	head := map[string]any{"alg": "ES256"}
+
+	t.Run("not yet valid", func(t *testing.T) {
+		body := map[string]any{"nbf": float64(time.Now().Unix() + 3600), "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{ValidateNotBefore: true})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not yet valid")
+	})
+
+	t.Run("already valid", func(t *testing.T) {
+		body := map[string]any{"nbf": float64(time.Now().Unix() - 3600), "_sd_alg": "sha-256"}
+		token := buildSignedSDJWT(t, head, body, signer)
+		sdJwt, err := New(token)
+		require.NoError(t, err)
+
+		err = sdJwt.Verify(VerificationOptions{ValidateNotBefore: true})
+		assert.NoError(t, err)
+	})
+}
+
+func TestVerify_KBJwtAudienceAndNonce(t *testing.T) {
+	issuerSigner, err := jws.GetSigner(model.ES256, nil)
+	require.NoError(t, err)
+	holderSigner, err := jws.GetSigner(model.ES256, nil)
+	require.NoError(t, err)
+
+	holderJwk, err := jwk.PublicJwk(holderSigner.Public())
+	require.NoError(t, err)
+
+	head := map[string]any{"alg": "ES256"}
+	body := map[string]any{
+		"sub":     "user_42",
+		"_sd_alg": "sha-256",
+		"cnf":    map[string]any{"jwk": *holderJwk},
+	}
+
+	token := buildSignedSDJWT(t, head, body, issuerSigner)
+	sdJwt, err := New(token)
+	require.NoError(t, err)
+
+	sdToken, err := sdJwt.Token()
+	require.NoError(t, err)
+
+	h := sha256.New()
+	h.Write([]byte(*sdToken))
+	sdHash := base64.RawURLEncoding.EncodeToString(h.Sum(nil))
+
+	kbHead := map[string]string{"typ": "kb+jwt", "alg": "ES256"}
+	kbBody := map[string]any{
+		"iat":     time.Now().Unix(),
+		"aud":     "https://verifier.example.com",
+		"nonce":   "abc123",
+		"sd_hash": sdHash,
+	}
+
+	kbHeadBytes, _ := json.Marshal(kbHead)
+	kbBodyBytes, _ := json.Marshal(kbBody)
+	kbB64Head := base64.RawURLEncoding.EncodeToString(kbHeadBytes)
+	kbB64Body := base64.RawURLEncoding.EncodeToString(kbBodyBytes)
+	kbSignInput := kbB64Head + "." + kbB64Body
+
+	kbSig, err := holderSigner.Sign(rand.Reader, []byte(kbSignInput), nil)
+	require.NoError(t, err)
+	kbB64Sig := base64.RawURLEncoding.EncodeToString(kbSig)
+
+	fullToken := *sdToken + kbB64Head + "." + kbB64Body + "." + kbB64Sig
+	sdJwtWithKb, err := New(fullToken)
+	require.NoError(t, err)
+
+	t.Run("matching audience", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			ExpectedAudience: utils.Pointer("https://verifier.example.com"),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong audience", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			ExpectedAudience: utils.Pointer("https://wrong.example.com"),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "audience mismatch")
+	})
+
+	t.Run("matching nonce", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			ExpectedNonce: utils.Pointer("abc123"),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong nonce", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			ExpectedNonce: utils.Pointer("wrong"),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nonce mismatch")
+	})
+
+	t.Run("kb-jwt signature verification", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			VerifyKBJwtSignature: true,
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("full verification", func(t *testing.T) {
+		err := sdJwtWithKb.Verify(VerificationOptions{
+			IssuerKey:            issuerSigner.Public(),
+			VerifyKBJwtSignature: true,
+			ExpectedAudience:     utils.Pointer("https://verifier.example.com"),
+			ExpectedNonce:        utils.Pointer("abc123"),
+		})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
Adds a `Verify(opts VerificationOptions)` method to `SdJwt` with configurable checks:

- **Issuer JWT signature verification** — validates the JWT signature against a provided public key using go-jose. Supports ES256/384/512, RS256/384/512, PS256/384/512.
- **Temporal validation** — optional `exp` and `nbf` claim checks against current time. No error if claims are absent.
- **KB-JWT audience/nonce** — validates the KB-JWT `aud` and `nonce` claims match expected values.
- **KB-JWT signature verification** — extracts the holder's public key from the `cnf.jwk` claim in the issuer JWT and verifies the KB-JWT signature. Supports all JWK formats handled by go-jose.

All checks are opt-in via `VerificationOptions` fields. Structural validation remains in `New()`/`NewFromComponents()`.

## Test plan
- [x] Issuer signature: valid key, wrong key, no key (skip)
- [x] Expiry: expired, valid, absent claim, disabled by default
- [x] Not-before: future nbf, past nbf
- [x] KB-JWT aud/nonce: matching, mismatched
- [x] KB-JWT signature: valid holder key
- [x] Full combined verification
- [x] All existing tests still pass