### PR TITLE
Use original token bytes for issuer signature verification

### DIFF
--- a/sd-jwt.go
+++ b/sd-jwt.go
@@ -31,6 +31,8 @@ type SdJwt struct {
 	Signature   string
 	KbJwt       *kbjwt.KbJwt
 	Disclosures []disclosure.Disclosure
+	rawHead     string
+	rawPayload  string
 }
 
 // New
@@ -293,6 +295,8 @@ func validateJwt(token string) (*SdJwt, error) {
 	}
 
 	sdJwt.Head = jwtHead
+	sdJwt.rawHead = tokenSections[0]
+	sdJwt.rawPayload = tokenSections[1]
 
 	sdJwt.Signature = tokenSections[2]
 

--- a/verify.go
+++ b/verify.go
@@ -85,16 +85,7 @@ func (s *SdJwt) verifyIssuerSignature(issuerKey crypto.PublicKey) error {
 		return fmt.Errorf("%wfailed to create signature validator: %w", e.ErrInvalidToken, err)
 	}
 
-	headBytes, err := json.Marshal(s.Head)
-	if err != nil {
-		return fmt.Errorf("failed to marshal header for verification: %w", err)
-	}
-	bodyBytes, err := json.Marshal(s.Body)
-	if err != nil {
-		return fmt.Errorf("failed to marshal body for verification: %w", err)
-	}
-
-	signInput := base64.RawURLEncoding.EncodeToString(headBytes) + "." + base64.RawURLEncoding.EncodeToString(bodyBytes)
+	signInput := s.rawHead + "." + s.rawPayload
 
 	sigBytes, err := base64.RawURLEncoding.DecodeString(s.Signature)
 	if err != nil {


### PR DESCRIPTION
## Summary
Fixes a bug in `verifyIssuerSignature` where the signing input was reconstructed by re-marshalling `s.Head` and `s.Body` Go maps back to JSON. This would produce different bytes than the original token due to:
- Go's `json.Marshal` sorting map keys alphabetically
- Potential floating-point formatting differences

The fix stores the original base64url-encoded header and payload strings (`rawHead`, `rawPayload`) on the `SdJwt` struct during parsing and uses those directly for signature verification.

## Changes
- `sd-jwt.go`: Add `rawHead` and `rawPayload` fields to `SdJwt`, populated in `validateJwt()`
- `verify.go`: Use `s.rawHead + "." + s.rawPayload` instead of re-marshalling

## Test plan
- [x] All existing tests pass
- [x] Verification tests still pass (they were working before because test tokens were constructed in Go with the same marshal ordering — real-world tokens from other implementations would have failed)